### PR TITLE
feat: TORRC and HSTORRC_<SERVICE> env vars for custom configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,21 +187,15 @@ docker run -d \
 
 ### Custom torrc directives
 
-Two env vars accept multi-line torrc content verbatim and are appended to
-the generated `/etc/tor/torrc` at boot:
+Two env vars accept multi-line torrc content, appended to `/etc/tor/torrc` at boot:
 
 | Variable | Where it lands | Use for |
 |----------|----------------|---------|
-| `TORRC` | After `SocksPort`, before any hidden service section | Global directives (`ControlPort`, `Log`, `ClientUseIPv6`, …) |
-| `HSTORRC_<SERVICE>` | Immediately after that service's `HiddenServicePort` line | Per-service directives (`HiddenServicePoWDefensesEnabled`, `HiddenServiceMaxStreams`, …) |
+| `TORRC` | After `SocksPort`, before any hidden service section | Global directives |
+| `HSTORRC_<SERVICE>` | After that service's `HiddenServicePort` line | Per-service directives (PoW, IntroDoS, MaxStreams, …) |
 
-Service names with hyphens map to underscores when forming the env var
-name (`HS_MY-API` → `HSTORRC_MY_API`), since POSIX env names cannot
-contain hyphens.
-
-The content is appended verbatim (only NUL bytes and CR are stripped).
-Tor validates directives at startup; bad config fails fast with a clear
-error in the container logs.
+Hyphens in service names become underscores (`HS_MY-API` → `HSTORRC_MY_API`).
+Tor validates directives at startup; bad config fails fast in the logs.
 
 ```yaml
 services:
@@ -212,14 +206,9 @@ services:
       HS_WEB: web:80:80
       HS_API: api:8080:80
 
-      # Global directives, applied to the whole tor instance.
       TORRC: |
         ClientUseIPv6 1
 
-      # Per-service hardening for WEB only. Proof-of-Work makes onion
-      # clients spend CPU before reaching the introduction circuit, which
-      # blunts DoS swarms. IntroDoSDefense caps introduction rate per
-      # circuit.
       HSTORRC_WEB: |
         HiddenServicePoWDefensesEnabled 1
         HiddenServicePoWQueueRate 250
@@ -228,15 +217,12 @@ services:
         HiddenServiceEnableIntroDoSRatePerSec 25
         HiddenServiceEnableIntroDoSBurstPerSec 200
 
-      # Cap concurrent streams per circuit on the API service. Useful for
-      # API endpoints where one client opening hundreds of streams is
-      # almost certainly abuse.
       HSTORRC_API: |
         HiddenServiceMaxStreams 50
         HiddenServiceMaxStreamsCloseCircuit 1
 ```
 
-To debug, exec into the container and inspect the rendered torrc:
+Inspect the rendered config:
 
 ```bash
 docker exec tor-hidden-service cat /etc/tor/torrc

--- a/README.md
+++ b/README.md
@@ -185,6 +185,63 @@ docker run -d \
   api:api-container:8080:80
 ```
 
+### Custom torrc directives
+
+Two env vars accept multi-line torrc content verbatim and are appended to
+the generated `/etc/tor/torrc` at boot:
+
+| Variable | Where it lands | Use for |
+|----------|----------------|---------|
+| `TORRC` | After `SocksPort`, before any hidden service section | Global directives (`ControlPort`, `Log`, `ClientUseIPv6`, …) |
+| `HSTORRC_<SERVICE>` | Immediately after that service's `HiddenServicePort` line | Per-service directives (`HiddenServicePoWDefensesEnabled`, `HiddenServiceMaxStreams`, …) |
+
+Service names with hyphens map to underscores when forming the env var
+name (`HS_MY-API` → `HSTORRC_MY_API`), since POSIX env names cannot
+contain hyphens.
+
+The content is appended verbatim (only NUL bytes and CR are stripped).
+Tor validates directives at startup; bad config fails fast with a clear
+error in the container logs.
+
+```yaml
+services:
+  tor:
+    image: ghcr.io/hundehausen/tor-hidden-service:latest
+    environment:
+      SOCKS_BIND: 127.0.0.1
+      HS_WEB: web:80:80
+      HS_API: api:8080:80
+
+      # Global directives, applied to the whole tor instance.
+      TORRC: |
+        ClientUseIPv6 1
+
+      # Per-service hardening for WEB only. Proof-of-Work makes onion
+      # clients spend CPU before reaching the introduction circuit, which
+      # blunts DoS swarms. IntroDoSDefense caps introduction rate per
+      # circuit.
+      HSTORRC_WEB: |
+        HiddenServicePoWDefensesEnabled 1
+        HiddenServicePoWQueueRate 250
+        HiddenServicePoWQueueBurst 1000
+        HiddenServiceEnableIntroDoSDefense 1
+        HiddenServiceEnableIntroDoSRatePerSec 25
+        HiddenServiceEnableIntroDoSBurstPerSec 200
+
+      # Cap concurrent streams per circuit on the API service. Useful for
+      # API endpoints where one client opening hundreds of streams is
+      # almost certainly abuse.
+      HSTORRC_API: |
+        HiddenServiceMaxStreams 50
+        HiddenServiceMaxStreamsCloseCircuit 1
+```
+
+To debug, exec into the container and inspect the rendered torrc:
+
+```bash
+docker exec tor-hidden-service cat /etc/tor/torrc
+```
+
 ## 🛡️ Security
 
 ### Hardening Checklist

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,18 +13,11 @@ services:
     build: .
     container_name: tor-hidden-service
     environment:
-      # Format: HS_[NAME]=[HOST]:[PORT]:[VIRTUAL_PORT]
+      # HS_[NAME]: [HOST]:[PORT]:[VIRTUAL_PORT]
       HS_WEB: web:80:80
-      # SECURITY: Set SOCKS_BIND=127.0.0.1 to restrict SOCKS proxy to
-      # localhost only. Default is 0.0.0.0 for backward compatibility but
-      # will change to 127.0.0.1 in v2.0.
-      # SOCKS_BIND: 127.0.0.1
+      # SOCKS_BIND: 127.0.0.1   # restrict SOCKS to localhost (default 0.0.0.0 until v2.0)
       #
-      # Optional: opt-in DoS hardening on the WEB onion. PoW makes onion
-      # clients spend CPU before reaching an introduction circuit; the
-      # IntroDoSDefense lines cap introduction rate per circuit. See the
-      # "Custom torrc directives" section in README.md for the full
-      # mechanism and the TORRC global counterpart.
+      # Per-HS DoS hardening. See README "Custom torrc directives".
       # HSTORRC_WEB: |
       #   HiddenServicePoWDefensesEnabled 1
       #   HiddenServicePoWQueueRate 250

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,10 +13,25 @@ services:
     build: .
     container_name: tor-hidden-service
     environment:
-      - HS_WEB=web:80:80  # Format: HS_[NAME]=[HOST]:[PORT]:[VIRTUAL_PORT]
-      # SECURITY: Set SOCKS_BIND=127.0.0.1 to restrict SOCKS proxy to localhost only
-      # Default is 0.0.0.0 for backward compatibility but will change to 127.0.0.1 in v2.0
-      # - SOCKS_BIND=127.0.0.1
+      # Format: HS_[NAME]=[HOST]:[PORT]:[VIRTUAL_PORT]
+      HS_WEB: web:80:80
+      # SECURITY: Set SOCKS_BIND=127.0.0.1 to restrict SOCKS proxy to
+      # localhost only. Default is 0.0.0.0 for backward compatibility but
+      # will change to 127.0.0.1 in v2.0.
+      # SOCKS_BIND: 127.0.0.1
+      #
+      # Optional: opt-in DoS hardening on the WEB onion. PoW makes onion
+      # clients spend CPU before reaching an introduction circuit; the
+      # IntroDoSDefense lines cap introduction rate per circuit. See the
+      # "Custom torrc directives" section in README.md for the full
+      # mechanism and the TORRC global counterpart.
+      # HSTORRC_WEB: |
+      #   HiddenServicePoWDefensesEnabled 1
+      #   HiddenServicePoWQueueRate 250
+      #   HiddenServicePoWQueueBurst 1000
+      #   HiddenServiceEnableIntroDoSDefense 1
+      #   HiddenServiceEnableIntroDoSRatePerSec 25
+      #   HiddenServiceEnableIntroDoSBurstPerSec 200
     networks:
       - tor-network
     volumes:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -67,11 +67,7 @@ else
     echo "SOCKS proxy configured to bind to: ${SOCKS_BIND}:9050"
 fi
 
-# Append a multi-line block of torrc directives (verbatim) under a labeled
-# section header. NUL bytes and CR are stripped so values pasted from
-# Windows-edited sources or accidentally containing binary noise do not
-# corrupt the config. Tor itself validates directive names and values at
-# startup; this layer does not reimplement that.
+# Append a torrc block under a section comment. Strips NUL/CR.
 append_torrc_block() {
     block_label=$1
     block_content=$2
@@ -85,8 +81,6 @@ append_torrc_block() {
     printf '%s\n' "$block_content" | tr -d '\000\r' | sed 's/^/    /'
 }
 
-# Global custom torrc from the TORRC env var. Inserted after SocksPort and
-# before any HiddenService section so directives are scoped globally.
 append_torrc_block "Custom global torrc (TORRC env var)" "${TORRC:-}"
 
 # Security validation functions
@@ -219,10 +213,7 @@ create_hidden_service() {
     printf 'HiddenServiceDir %s\n' "$service_dir" >> /etc/tor/torrc
     printf 'HiddenServicePort %s %s:%s\n' "$virtual_port" "$target_host" "$target_port" >> /etc/tor/torrc
 
-    # Per-service custom torrc from HSTORRC_<SERVICE>. Hyphens in service
-    # names map to underscores for env-var lookup (POSIX env names cannot
-    # contain hyphens). Tor groups directives by HiddenServiceDir, so any
-    # HS-specific directives appended here scope to this service only.
+    # Hyphens in service names become underscores; env names can't have hyphens.
     hs_torrc_var="HSTORRC_$(printf '%s' "$service_name" | tr '-' '_')"
     eval "hs_torrc_value=\${${hs_torrc_var}-}"
     append_torrc_block "Per-service torrc (${hs_torrc_var})" "$hs_torrc_value"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -67,6 +67,28 @@ else
     echo "SOCKS proxy configured to bind to: ${SOCKS_BIND}:9050"
 fi
 
+# Append a multi-line block of torrc directives (verbatim) under a labeled
+# section header. NUL bytes and CR are stripped so values pasted from
+# Windows-edited sources or accidentally containing binary noise do not
+# corrupt the config. Tor itself validates directive names and values at
+# startup; this layer does not reimplement that.
+append_torrc_block() {
+    block_label=$1
+    block_content=$2
+
+    [ -z "$block_content" ] && return 0
+
+    printf '\n# %s\n' "$block_label" >> /etc/tor/torrc
+    printf '%s\n' "$block_content" | tr -d '\000\r' >> /etc/tor/torrc
+
+    echo "==> Appended ${block_label}:"
+    printf '%s\n' "$block_content" | tr -d '\000\r' | sed 's/^/    /'
+}
+
+# Global custom torrc from the TORRC env var. Inserted after SocksPort and
+# before any HiddenService section so directives are scoped globally.
+append_torrc_block "Custom global torrc (TORRC env var)" "${TORRC:-}"
+
 # Security validation functions
 validate_service_name() {
     local name=$1
@@ -193,8 +215,17 @@ create_hidden_service() {
     }
 
     # Add hidden service configuration to torrc
+    printf '\n# Hidden service: %s\n' "$service_name" >> /etc/tor/torrc
     printf 'HiddenServiceDir %s\n' "$service_dir" >> /etc/tor/torrc
     printf 'HiddenServicePort %s %s:%s\n' "$virtual_port" "$target_host" "$target_port" >> /etc/tor/torrc
+
+    # Per-service custom torrc from HSTORRC_<SERVICE>. Hyphens in service
+    # names map to underscores for env-var lookup (POSIX env names cannot
+    # contain hyphens). Tor groups directives by HiddenServiceDir, so any
+    # HS-specific directives appended here scope to this service only.
+    hs_torrc_var="HSTORRC_$(printf '%s' "$service_name" | tr '-' '_')"
+    eval "hs_torrc_value=\${${hs_torrc_var}-}"
+    append_torrc_block "Per-service torrc (${hs_torrc_var})" "$hs_torrc_value"
 
     echo "Configured hidden service for $service_name: $target_host:$target_port -> $virtual_port"
 }


### PR DESCRIPTION
Two env vars for adding torrc directives:

  - `TORRC`: appended after `SocksPort`
  - `HSTORRC_<SERVICE>`: appended inside that hidden service's section

Both accept multi-line content; comments and repeated directives work as in a real torrc. Hyphens in service names map to underscores for the env name. Behavior is unchanged when the vars are unset.

 I needed this to enable `HiddenServicePoWDefensesEnabled` + `HiddenServiceEnableIntroDoSDefense`  on [kycnot.me](https://kycnot.me) .onion under sustained bot pressure:

  ```yaml
  HSTORRC_WEB: |
    HiddenServicePoWDefensesEnabled 1
    HiddenServicePoWQueueRate 250
    HiddenServicePoWQueueBurst 1000
    HiddenServiceEnableIntroDoSDefense 1
    HiddenServiceEnableIntroDoSRatePerSec 25
    HiddenServiceEnableIntroDoSBurstPerSec 200
  ```

Tested locally against tor 0.4.9.8 and on kycnot.me: directives parse, onion bootstraps, generated  `/etc/tor/torrc` is good. Github builds also [pass](https://github.com/pluja/tor-hidden-service-docker-torrc-configs/actions/runs/26528808145), and generated image is live on kycnot.me's onion site.

Closed old PR because it got behind your commits; this branch is updated. Feel free to close if you don't like it!