### PR TITLE
ci: SBOM, provenance, sigstore signature

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,10 +22,11 @@ concurrency:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -58,6 +59,10 @@ jobs:
         docker stop tor-test && docker rm tor-test
     
   publish:
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
     runs-on: ubuntu-latest
     needs: build
     if: github.event_name != 'pull_request'
@@ -99,12 +104,35 @@ jobs:
           type=raw,value=tor-${{ env.TOR_VERSION }},enable=${{ env.TOR_VERSION != '' }}
     
     - name: Build and push Docker image
+      id: build
       uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
       with:
         context: .
         platforms: linux/amd64,linux/arm64
         push: true
+        sbom: true
+        provenance: mode=max
         tags: ${{ steps.meta.outputs.tags }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
         labels: ${{ steps.meta.outputs.labels }}
+
+    - name: Install cosign
+      uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+      with:
+        cosign-release: v3.1.1
+
+    - name: Sign the published image digest
+      env:
+        DIGEST: ${{ steps.build.outputs.digest }}
+        TAGS: ${{ steps.meta.outputs.tags }}
+        IMAGE: ghcr.io/${{ github.repository_owner }}/tor-hidden-service
+      shell: bash
+      run: |
+        set -euo pipefail
+        IFS=$'\n\t'
+        images=()
+        for tag in ${TAGS}; do
+          images+=("${tag}@${DIGEST}")
+        done
+        cosign sign --recursive --yes "${images[@]}"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A lightweight, secure Docker container for running Tor hidden services. Built on
 - [🔑 Key Persistence](#-key-persistence)
 - [📚 Examples](#-examples)
 - [💓 Health Checks](#-health-checks)
+- [🔐 Supply Chain](#-supply-chain)
 - [🔍 Troubleshooting](#-troubleshooting)
 - [🤝 Contributing](#-contributing)
 
@@ -353,6 +354,44 @@ Check health status:
 ```bash
 docker ps --filter name=tor-hidden-service --format "table {{.Names}}\t{{.Status}}"
 ```
+
+## 🔐 Supply Chain
+
+Every published image on `ghcr.io/hundehausen/tor-hidden-service` ships with three attestations:
+
+- **SBOM** (Software Bill of Materials, SPDX 2.3) — every package inside the image
+- **Provenance** (SLSA v0.2) — how the image was built, from which commit, by which CI
+- **Sigstore signature** — keyless, signed via GitHub OIDC, recorded in Rekor
+
+### Verifying the signature
+
+Requires [cosign](https://docs.sigstore.dev/cosign/system_config/installation/):
+
+```bash
+cosign verify ghcr.io/hundehausen/tor-hidden-service:latest \
+  --certificate-identity-regexp 'https://github\.com/hundehausen/tor-hidden-service-docker/\.github/workflows/.+' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
+```
+
+Exit code 0 and a JSON payload listing one signature means the image was built by this repo's CI — not a third-party reupload.
+
+### Inspecting the SBOM
+
+```bash
+docker buildx imagetools inspect ghcr.io/hundehausen/tor-hidden-service:latest \
+  --format '{{ json (index .SBOM "linux/amd64").SPDX }}'
+```
+
+Returns SPDX JSON listing every Alpine package and version inside the image.
+
+### Inspecting provenance
+
+```bash
+docker buildx imagetools inspect ghcr.io/hundehausen/tor-hidden-service:latest \
+  --format '{{ json .Provenance }}'
+```
+
+Returns SLSA v0.2 JSON with the source repo URL, commit SHA, builder version, and platform. Confirms the image came from this repo's `main` branch at a specific commit.
 
 ## 🔍 Troubleshooting
 


### PR DESCRIPTION
## 🔐 Supply Chain

Every published image on `ghcr.io/hundehausen/tor-hidden-service` ships with three attestations:

- **SBOM** (Software Bill of Materials, SPDX 2.3) — every package inside the image
- **Provenance** (SLSA v0.2) — how the image was built, from which commit, by which CI
- **Sigstore signature** — keyless, signed via GitHub OIDC, recorded in Rekor